### PR TITLE
removes firebase dependency

### DIFF
--- a/packages/solid-firebase/package.json
+++ b/packages/solid-firebase/package.json
@@ -38,7 +38,6 @@
     "solid-js": ">= 1.0.0"
   },
   "dependencies": {
-    "firebase": "^9.6.11",
     "solid-js": "^1.3.16"
   },
   "devDependencies": {


### PR DESCRIPTION
Firebase should be installed as a dependency in the app using this package and then here only used as a `peerDependency`, otherwise you can get 2 instances of firebase which cause further issues.