### PR TITLE
fix: use existing auth state if it exists

### DIFF
--- a/packages/solid-firebase/src/hooks/useAuth.tsx
+++ b/packages/solid-firebase/src/hooks/useAuth.tsx
@@ -14,8 +14,8 @@ export function useAuth(auth: Auth) {
     data: User | null
     error: Error | null
   }>({
-    loading: true,
-    data: null,
+    loading: auth.currentUser == null,
+    data: auth.currentUser,
     error: null,
   })
 


### PR DESCRIPTION
This makes it such that when using these in nested components, i.e.:

```ts
const app = initializeApp(firebaseConfig);
const auth = getAuth(app);

function App() {
    return <GuardedByAuth>
        <Route path='/profile' component={Profile} />
    </GuardedByAuth>
}

function GuardedByAuth() {
  const state = useAuth(auth)

  return (
    <Switch>
      <Match when={state.loading}>
        <p>Loading...</p>
      </Match>
      <Match when={state.error}>
        <Login />
      </Match>
      <Match when={state.data}>
        <Profile />
      </Match>
    </Switch>
  )
}
```
Do not get into a loading state again and do not have to handle it, i.e.:

```ts
function Profile() { 
    const data = useAuth(auth); // not loading, since user already authenticated.
   return <div>data.user.name</div>
}
```

