### PR TITLE
Add fallback to Switch in auth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ function App() {
   const state = useAuth(getAuth(app))
 
   return (
-    <Switch>
+    <Switch fallback={<Login />}>
       <Match when={state.loading}>
         <p>Loading...</p>
       </Match>


### PR DESCRIPTION
The following payload is the default when initializing auth in a new project given the provided code:

`{"loading":false,"data":null,"error":null}`

This means the `state.error` match is never hit, thus the `Login` component is never rendered.